### PR TITLE
Also escape ::

### DIFF
--- a/src/syntax_highlighting/main.py
+++ b/src/syntax_highlighting/main.py
@@ -424,11 +424,14 @@ def process_html(html):
     """Modify highlighter output to address some Anki idiosyncracies"""
     # 1.) "Escape" curly bracket sequences reserved to Anki's card template
     # system by placing an invisible html tag inbetween
-    html = re.sub(r"{{", "{<!---->{", html)
-    html = re.sub(r"}}", "}<!---->}", html)
+    for pattern, replacement in ((r"{{", r"{<!---->{"),
+                                 (r"}}", r"}<!---->}"),
+                                 (r"::", r":<!---->:")):
+        html = re.sub(pattern, replacement, html)
     return html
 
 # Hooks and monkey-patches
+
 
 if anki21:
     addHook("setupEditorButtons", onSetupButtons21)


### PR DESCRIPTION
#### Description

`::` also has a special meaning for Anki, as separator between Cloze content and hint. This addon already escapes `{{` and `}}`. Add escaping for `::`.


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
