### PR TITLE
When pasting, strip common padding of entire block of code

### DIFF
--- a/src/syntax_highlighting/main.py
+++ b/src/syntax_highlighting/main.py
@@ -375,11 +375,32 @@ def highlight_code(ed):
         # Get the code from the clipboard
         code = clipboard.text()
 
+    # Search in each line for the first non-whitespace character,
+    # and calculate minimum padding shared between all lines.
+    lines = code.splitlines()
+    starting_space = sys.maxsize
+    
+    for l in lines:
+        # only interested in non-empty lines
+        if len(l.strip()) > 0:
+            # get the index of the first non whitespace character
+            s = len(l) - len(l.lstrip())
+            # is it smaller than anything found?
+            if s < starting_space:
+                starting_space = s
+    
+    # if we found a minimum number of chars we can strip off each line, do it.
+    if (starting_space < sys.maxsize):
+        code = '';    
+        for l in lines:
+            code = code + l[starting_space:] + '\n'
+
     langAlias = ed.codeHighlightLangAlias
 
-    # Select the lexer for the correct language
+    # Select the lexer for the correct language.
+    # Should not strip leading and trailing whitespace from the input.
     try:
-        my_lexer = get_lexer_by_name(langAlias, stripall=True)
+        my_lexer = get_lexer_by_name(langAlias, stripall=False)
     except ClassNotFound as e:
         print(e)
         showError(ERR_LEXER, parent=ed.parentWindow)


### PR DESCRIPTION
#### Description

Before pasting a block of code, all _common_ padding is stripped, but relative indentation is preserved.
I needed this because C# tends to have a lot of indentation if the interesting code happens to be already nested deep in some namespace/class/function. By trimming the common white space, the code is much easier to read on a cell phone with limited space (less need for horizontal scrolling).

For example, copying and pasting:

```C#
                param.MetaRequest = new BoxMetaRequest[]
                {
                    new BoxMetaRequest()
                    {
                          Name = "Frame",
                    }
                }
```

Becomes:

```C#
param.MetaRequest = new BoxMetaRequest[]
{
    new BoxMetaRequest()
    {
          Name = "Frame",
    }
}
```

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version: 10
  - [ ] macOS, version: 
- [x] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [x] AnkiDroid, version: 2.9.2
  - [x] AnkiWeb
