### PR TITLE
added JSX formatting to JavaScript

### DIFF
--- a/src/syntax_highlighting/libs/pygments/lexers/_mapping.py
+++ b/src/syntax_highlighting/libs/pygments/lexers/_mapping.py
@@ -217,6 +217,7 @@ LEXERS = {
     'JsonLdLexer': ('pygments.lexers.data', 'JSON-LD', ('jsonld', 'json-ld'), ('*.jsonld',), ('application/ld+json',)),
     'JsonLexer': ('pygments.lexers.data', 'JSON', ('json',), ('*.json',), ('application/json',)),
     'JspLexer': ('pygments.lexers.templates', 'Java Server Page', ('jsp',), ('*.jsp',), ('application/x-jsp',)),
+    'JsxLexer': ('pygments.lexers.jsx', 'JSX', ('jsx', 'react'), ('*.jsx', '*.react'), ('text/jsx', 'text/typescript-jsx')),
     'JuliaConsoleLexer': ('pygments.lexers.julia', 'Julia console', ('jlcon',), (), ()),
     'JuliaLexer': ('pygments.lexers.julia', 'Julia', ('julia', 'jl'), ('*.jl',), ('text/x-julia', 'application/x-julia')),
     'JuttleLexer': ('pygments.lexers.javascript', 'Juttle', ('juttle', 'juttle'), ('*.juttle',), ('application/juttle', 'application/x-juttle', 'text/x-juttle', 'text/juttle')),

--- a/src/syntax_highlighting/libs/pygments/lexers/jsx.py
+++ b/src/syntax_highlighting/libs/pygments/lexers/jsx.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+    Copyright (C) 2017 by Flavio Curella - https://github.com/fcurella/jsx-lexer
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
+    Minor changes made by Colin Hughes to get it working with Anki
+"""
+
+import re
+
+from pygments.lexer import bygroups, include, default
+from pygments.lexers.javascript import JavascriptLexer
+from pygments.token import Name, Operator, Punctuation, String, Text
+
+__all__ = ['JsxLexer']
+
+# Use same tokens as `JavascriptLexer`, but with tags and attributes support
+TOKENS = JavascriptLexer.tokens
+TOKENS.update(
+    {
+        "jsx": [
+            (
+                r"(<)(/?)(>)",
+                bygroups(Punctuation, Punctuation, Punctuation),
+            ),  # JSXFragment <>|</>
+            (r"(<)([\w]+)(\.?)", bygroups(Punctuation, Name.Tag, Punctuation), "tag"),
+            (
+                r"(<)(/)([\w]+)(>)",
+                bygroups(Punctuation, Punctuation, Name.Tag, Punctuation),
+            ),
+            (
+                r"(<)(/)([\w]+)",
+                bygroups(Punctuation, Punctuation, Name.Tag),
+                "fragment",
+            ),  # Same for React.Context
+        ],
+        "tag": [
+            (r"\s+", Text),
+            (r"([\w]+\s*)(=)(\s*)", bygroups(Name.Attribute, Operator, Text), "attr"),
+            (r"[{}]+", Punctuation),
+            (r"[\w\.]+", Name.Attribute),
+            (r"(/?)(\s*)(>)", bygroups(Punctuation, Text, Punctuation), "#pop"),
+        ],
+        "fragment": [
+            (r"(.)([\w]+)", bygroups(Punctuation, Name.Attribute)),
+            (r"(>)", bygroups(Punctuation), "#pop"),
+        ],
+        "attr": [
+            ("{", Punctuation, "expression"),
+            ('".*?"', String, "#pop"),
+            ("'.*?'", String, "#pop"),
+            default("#pop"),
+        ],
+        "expression": [
+            ("{", Punctuation, "#push"),
+            ("}", Punctuation, "#pop"),
+            include("root"),
+        ],
+    }
+)
+TOKENS["root"].insert(0, include("jsx"))
+
+
+class JsxLexer(JavascriptLexer):
+    name = "JSX"
+    aliases = ["jsx", "react"]
+    filenames = ["*.jsx", "*.react"]
+    mimetypes = ["text/jsx", "text/typescript-jsx"]
+
+    flags = re.MULTILINE | re.DOTALL | re.UNICODE
+
+    tokens = TOKENS


### PR DESCRIPTION
#### Description

[This comment](https://github.com/glutanimate/syntax-highlighting/issues/9#issuecomment-525381595) by [@hbergren](https://github.com/hbergren) prompted me to pull [this repo](https://github.com/fcurella/jsx-lexer/blob/master/jsx/lexer.py) into syntax-highlighting. With a couple of tweeks it's working. I have added a "JSX" option to the menu. I also wondered if there should also be a "React" option that does the same as this, but that seemed unnecessary to me so I didn't do that.

I didn't follow the contributing guidelines in my previous pull request and just realised I hadn't created a dedicated branch to hold the changes (I just used a repo I wasn't going to use for anything else).

I have now done it as Glutanimate requested.

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
