### PR TITLE
Import `json` directly

### DIFF
--- a/src/syntax_highlighting/main.py
+++ b/src/syntax_highlighting/main.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 import os
 import sys
 import re
+import json
 
 from .consts import *  # import addon_path
 # always use shipped pygments library
@@ -33,7 +34,6 @@ from aqt.qt import *
 from aqt import mw
 from aqt.editor import Editor
 from aqt.utils import showWarning
-from anki.utils import json
 from anki.hooks import addHook, wrap
 
 from .config import local_conf


### PR DESCRIPTION
#### Description
Removes warning in `pylib/anki/utils.py` line 42 ([link](https://github.com/ankitects/anki/blob/312fa278984ba26a49489cfaa5b406450747cf1e/pylib/anki/utils.py#L42
)):
![image](https://user-images.githubusercontent.com/45272873/110255808-7da4ca00-7f8d-11eb-97e5-3063dde78aee.png)
Its an admittedly minor issue, but printing the traceback is something that clutters the terminal up when building and running anki.

#### Checklist:
- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Ubuntu LTS
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
