### PR TITLE
Fix(IndexError): Handle unexpected System level pygments import

### DIFF
--- a/src/syntax_highlighting/main.py
+++ b/src/syntax_highlighting/main.py
@@ -53,7 +53,11 @@ LIMITED_LANGS = local_conf["limitToLangs"]
 #                        to show the user AND
 #  The "language aliases": short, cryptic names for internal
 #                          use by HtmlFormatter
-LANGUAGES_MAP = {lex[0]: lex[1][0] for lex in get_all_lexers()}
+LANGUAGES_MAP = {
+    lex[0]: lex[1][0]
+    for lex in get_all_lexers()
+    if len(lex) > 1 and len(lex[1])
+}
 
 
 ERR_LEXER = ("<b>Error</b>: Selected language not found.<br>"


### PR DESCRIPTION
#### Description

##### Problem
If pygments is installed via pip (In my case pygments version 2.15), it will be used regardless of the locally shipped pygments dependency.

##### Solution
Defensively checks bounds to ensure no index exception occurs.

#### Checklist:

- [**x**] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [**x**] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [**x** ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [**x**] I've tested my changes on at least one of the following platforms:
  - [**x**] Linux, version: Arch Linux
  - [**x** ] Windows, version: Windows 10
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
