### PR TITLE
allow version numbers that start with 23 or 24

### DIFF
--- a/src/syntax_highlighting/consts.py
+++ b/src/syntax_highlighting/consts.py
@@ -13,7 +13,7 @@ import sys
 import os
 from anki import version
 
-anki21 = version.startswith("2.1.")
+anki21 = version.startswith("2.1.") or version.startswith("23") or version.startswith("24")
 sys_encoding = sys.getfilesystemencoding()
 
 if anki21:


### PR DESCRIPTION
#### Description

On Anki version 23.10 and onwards, “Syntax Highlighting for Code” addon fails to load. This is due to `addon_path` not being correctly handled. 

This bug is fixed by allowing version numbers that start with 23 and 24. 

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [X] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [X] Latest standard Anki 23.12.1 binary build
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [X] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [ ] Windows, version:
  - [X] macOS, version: 13.0.1
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
